### PR TITLE
Upgraded gulp-sass dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "gulp-connect": "^2.1.0",
     "gulp-minify-css": "^0.3.11",
     "gulp-open": "^0.3.0",
-    "gulp-sass": "^1.2.0",
+    "gulp-sass": "^2.1.1",
     "gulp-webpack": "^1.0.0",
     "webpack": "^1.4.10"
   }


### PR DESCRIPTION
This repo doesn't build properly in Node 4.x+ otherwise.
